### PR TITLE
Prepare repo for use with Binder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+*.ipynb_checkpoints

--- a/environment.yaml
+++ b/environment.yaml
@@ -1,0 +1,30 @@
+name: mosdef-binder
+
+channels:
+  - conda-forge
+  - defaults
+  - mosdef
+  - omnia
+  - glotzer
+  - bioconda
+
+dependencies:
+  - python=3.5
+  - numpy
+  - scipy
+  - packmol=1.0.0
+  - nglview>=0.6.2.3
+  - oset
+  - parmed
+  - mdtraj
+  - gsd
+  - openbabel
+  - jupyter
+  - nbformat
+  - ipykernel
+  - openmm
+  - networkx
+  - six
+  - plyplus
+  - requests
+  - lxml

--- a/postBuild
+++ b/postBuild
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+mkdir src
+cd src
+
+git clone https://github.com/mosdef-hub/mbuild.git
+cd mbuild
+pip install .
+cd ..
+
+git clone https://github.com/mosdef-hub/foyer.git
+cd foyer
+pip install .
+cd ../..

--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+cd ..
 mkdir src
 cd src
 


### PR DESCRIPTION
I'm hoping to generate a Binder from this repo which requires the inclusion of some scripts to get a proper environment set up. [We've set up a Binder in the past](https://github.com/mosdef-hub/mbuild_binder) for the mBuild examples, although I'm hoping to now use this repo as the container for all MoSDeF related examples/tutorials.

I would like to use the update NGLview representation from mosdef-hub/mbuild#438, so for now I am building both mBuild and Foyer from source. After the next package releases, however, I plan to only use the `environment.yaml` script so that all packages (mBuild and Foyer included) are installed with conda.