### PR TITLE
Update atomtyping tests

### DIFF
--- a/mff_test1/test_atomtyping.py
+++ b/mff_test1/test_atomtyping.py
@@ -7,7 +7,7 @@ from foyer import Forcefield
 from foyer.tests.utils import atomtype
 
 MOL2_FILES = glob('test_molecules/*.mol2')
-FORCEFIELD_FILES = glob('*.xml')
+FORCEFIELD_FILES = glob('*test1.xml')
 
 FORCEFIELD = Forcefield(forcefield_files=FORCEFIELD_FILES)
 

--- a/mff_test2/test_atomtyping.py
+++ b/mff_test2/test_atomtyping.py
@@ -7,7 +7,7 @@ from foyer import Forcefield
 from foyer.tests.utils import atomtype
 
 MOL2_FILES = glob('test_molecules/*.mol2')
-FORCEFIELD_FILES = glob('*.xml')
+FORCEFIELD_FILES = glob('*test2.xml')
 
 FORCEFIELD = Forcefield(forcefield_files=FORCEFIELD_FILES)
 


### PR DESCRIPTION
Referencing #25, fixing the way that the forcefield XMLs are grabbed in `mff_test_1` and `mff_test_2`.