### PR TITLE
Update current tutorial notebooks that use recipes

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,16 +9,19 @@ channels:
   - bioconda
 
 dependencies:
-  - python=3.5
+  - python=3.7
   - numpy
   - scipy
-  - packmol=1.0.0
-  - nglview>=0.6.2.3
+  - packmol>=1!18.013
+  - nglview
+  - py3dmol
   - oset
   - parmed
   - mdtraj
+  - mbuild
+  - foyer
   - gsd
-  - openbabel
+  - openbabel>=3.0.0
   - jupyter
   - nbformat
   - ipykernel

--- a/foyer-overview.ipynb
+++ b/foyer-overview.ipynb
@@ -373,13 +373,6 @@
    "source": [
     "!cat octane_system_opls.top"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -399,7 +392,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.8"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/full-examples/bulk-alkane/bulk-alkane.ipynb
+++ b/full-examples/bulk-alkane/bulk-alkane.ipynb
@@ -21,9 +21,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import mbuild as mb"
@@ -39,9 +37,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class CH2(mb.Compound):\n",
@@ -76,7 +72,7 @@
     "            raise ValueError('n must be 1 or more')\n",
     "        super(Alkane, self).__init__()\n",
     "\n",
-    "        chain = mb.Polymer(CH2(), n=n, port_labels=('up', 'down'))\n",
+    "        chain = mb.recipes.Polymer(CH2(), n=n, port_labels=('up', 'down'))\n",
     "        self.add(chain, 'chain')\n",
     "        \n",
     "        up_cap = H()\n",
@@ -161,9 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "%%bash\n",
@@ -188,7 +182,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/mbuild-overview-STUDENT.ipynb
+++ b/mbuild-overview-STUDENT.ipynb
@@ -338,7 +338,7 @@
    "outputs": [],
    "source": [
     "# How many bonds do you expect to find\n",
-    "ch2.save('ch2.xyz')\n",
+    "ch2.save('ch2.xyz', overwrite=True)\n",
     "\n",
     "# list coordinates\n",
     "\n",
@@ -809,7 +809,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butane.energy_minimization()\n",
+    "butane.energy_minimize()\n",
     "butane.visualize()"
    ]
   },
@@ -827,7 +827,7 @@
    "outputs": [],
    "source": [
     "decane = Alkane(chain_length=10)\n",
-    "decane.energy_minimization()\n",
+    "decane.energy_minimize()\n",
     "decane.visualize()"
    ]
   },
@@ -965,7 +965,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "alkane_block = mb.Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
+    "alkane_block = mb.recipes.Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
     "alkane_block.visualize(show_ports=True)"
    ]
   },
@@ -1000,10 +1000,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pfa_block = mb.Polymer(monomers=CF2(), n=3, port_labels=('up', 'down'))\n",
-    "alkane_block = mb.Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
+    "pfa_block = mb.recipes.Polymer(monomers=CF2(), n=3, port_labels=('up', 'down'))\n",
+    "alkane_block = mb.recipes.Polymer(monomers=CH2(), n=3, port_labels=('up', 'down'))\n",
     "\n",
-    "semifluorinated_hexane = mb.Polymer(monomers=(alkane_block, pfa_block), sequence='ABAB', n=1, port_labels=('up', 'down'))\n",
+    "semifluorinated_hexane = mb.recipes.Polymer(monomers=(alkane_block, pfa_block), sequence='ABAB', n=1, port_labels=('up', 'down'))\n",
     "\n",
     "semifluorinated_hexane.visualize(show_ports=True)"
    ]
@@ -1190,7 +1190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tiled_surface = mb.TiledCompound(surface, n_tiles=(2, 1, 1))\n",
+    "tiled_surface = mb.recipes.TiledCompound(surface, n_tiles=(2, 1, 1))\n",
     "tiled_surface.visualize(show_ports=True)"
    ]
   },
@@ -1276,7 +1276,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.5"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/mbuild-overview.ipynb
+++ b/mbuild-overview.ipynb
@@ -365,8 +365,8 @@
     "Can add bonds explicitly using `compound.add_bonds` method\n",
     "\n",
     "Cons:\n",
-    "Not flexible\n",
-    "Tedious"
+    "* Not flexible\n",
+    "* Tedious"
    ]
   },
   {
@@ -509,6 +509,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import mbuild as mb\n",
+    "from mbuild.lib.atoms import H\n",
+    "from mbuild.recipes import recipes\n",
+    "from mbuild.lib.surfaces import AmorphousSilicaSurface\n",
+    "\n",
     "class CH2(mb.Compound):\n",
     "    def __init__(self):\n",
     "        super(CH2, self).__init__()\n",
@@ -518,9 +523,26 @@
     "        self.add([carbon, hydrogen0, hydrogen1])\n",
     "        self.add_bond((carbon, hydrogen0))\n",
     "        self.add_bond((carbon, hydrogen1))\n",
+    "        self.add(mb.Port(anchor=self[0], orientation=[0, 1, 0],\n",
+    "                         separation=0.07), label='up')\n",
+    "        self.add(mb.Port(anchor=self[0], orientation=[0, -1, 0],\n",
+    "                         separation=0.07), label='down')\n",
     "\n",
-    "ch2 = CH2()\n",
-    "ch2.visualize()"
+    "polymer = recipes.Polymer(monomers=CH2(), n=10)\n",
+    "locations = mb.pattern.Grid2DPattern(n=10, m=10)\n",
+    "functionalized_surface = recipes.Monolayer(AmorphousSilicaSurface(),\n",
+    "                                           polymer, backfill=H(), pattern=locations,\n",
+    "                                           tile_x=2, tile_y=1,)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from mbuild.lib.surfaces import AmorphousSilicaSurface\n",
+    "AmorphousSilicaSurface().save('surf.pdb', overwrite=True)"
    ]
   },
   {
@@ -820,7 +842,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butane.energy_minimization()\n",
+    "butane.energy_minimize()\n",
     "butane.visualize()"
    ]
   },
@@ -838,7 +860,7 @@
    "outputs": [],
    "source": [
     "decane = Alkane(chain_length=10)\n",
-    "decane.energy_minimization()\n",
+    "decane.energy_minimize()\n",
     "decane.visualize()"
    ]
   },
@@ -1227,7 +1249,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use mBuild's `Pattern` class to create a pattern to define the arrangement of molecules on the surface. Here, we will create a `Random2DPattern` of 50 points in *xy* space. The `apply_to_compound` method can be used to attach copies of a molecules to a surface at locations designated by the `Pattern`. We can also provide a backfill `Compound` (in this case hydrogen) to fill vacant sites."
+    "We can use mBuild's `Pattern` class to create a pattern to define the arrangement of molecules on the surface. Here, we will create a `Random2DPattern` of 10 points in *xy* space. The `apply_to_compound` method can be used to attach copies of a molecules to a surface at locations designated by the `Pattern`. We can also provide a backfill `Compound` (in this case hydrogen) to fill vacant sites."
    ]
   },
   {
@@ -1241,25 +1263,6 @@
     "chains, backfills = pattern.apply_to_compound(guest=octanol, host=tiled_surface, backfill=hydrogen)\n",
     "functionalized_surface = mb.Compound(subcompounds=[tiled_surface, chains, backfills])\n",
     "functionalized_surface.visualize()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Again, the above routines could be wrapped into a class. Here we'll load the `AlkaneMonolayer` class from mBuild's `examples` module. You can change `n` in the `Random2DPattern` instance to toggle the number of chains in the system. `tile_x` and `tile_y` can be toggled to expand the surface as desired, while `chain_length` can be toggled to alter the lengths of the alkylsilane chains."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from mbuild.examples import AlkaneMonolayer\n",
-    "pattern = mb.Random2DPattern(n=50, seed=123)\n",
-    "monolayer = AlkaneMonolayer(pattern=pattern, tile_x=2, tile_y=1, chain_length=12)\n",
-    "monolayer.visualize()"
    ]
   },
   {
@@ -1287,7 +1290,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/mbuild-overview.ipynb
+++ b/mbuild-overview.ipynb
@@ -338,7 +338,7 @@
    "outputs": [],
    "source": [
     "# How many bonds do you expect to find\n",
-    "ch2.save('ch2.xyz')\n",
+    "ch2.save('ch2.xyz', overwrite=True)\n",
     "new_ch2 = mb.load('./ch2.xyz')\n",
     "print(list(new_ch2.bonds()))\n",
     "list(new_ch2.particles())\n",

--- a/overview.ipynb
+++ b/overview.ipynb
@@ -55,7 +55,7 @@
    "outputs": [],
    "source": [
     "import mbuild as mb\n",
-    "print(mb.version)"
+    "print(mb.__version__)"
    ]
   },
   {
@@ -460,7 +460,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "butane.energy_minimization()"
+    "butane.energy_minimize()"
    ]
   },
   {
@@ -898,7 +898,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
With the switch to the plug-in recipe system for mBuild and foyer,
came the breaking change to the import location for common mbuild
recipes like Polymer and Monolayer.

This commit updates these now-deprecated commands.